### PR TITLE
Fix struct Barcode_Item memory leak

### DIFF
--- a/barcode/barcode_BarCode.c
+++ b/barcode/barcode_BarCode.c
@@ -53,4 +53,6 @@ JNIEXPORT void JNICALL Java_barcode_BarCode_Create
 
   (*env)->ReleaseStringUTFChars(env, code, codeStr);
   (*env)->ReleaseStringUTFChars(env, encoding, encodingStr);
+	
+  Barcode_Delete(bc);
 }


### PR DESCRIPTION
JNI `NewStringUTF` copies its argument to a JVM-managed heap, while `bc` never gets deallocated. 

`Barcode_Delete` for reference: https://github.com/batsuev/barcode/blob/e22e629884d9878e3b0c47f2a5b3f3d077f2a929/barcode/barcode-0.99/library.c#L51-L66